### PR TITLE
Updated README and full.psf for import

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 ### To get eclipse running:
 1. Install eMoflon IBeX: https://github.com/eMoflon/emoflon-ibex-democles and everything you need for the third IBeX handbook (Xtext, Xtend, ...)
-2. Import this PSF file into your workspace:  ** to be added **
+2. Import this PSF file into your workspace:  https://github.com/CN-UPB/nfv-dsl-qpn/blob/master/full.psf
 3. Alternatively, clone the repository and import the full.psf file into your workspace
 4. Go into Window -> Preferences -> Emfatic and activate "Automatically greate Ecore (\*.ecore) file when saving emfatic (\*.emf) file."
 5. Locate the VNF.emf file in the project VNF -> model -> VNF.emf make an arbitrary change like adding a whitespace and save the file.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 ### Troubleshooting
 
 - If an error occurrs in the vnf\_to\_qpn\_xtext.ui.tests project while cleaning, building and generating the workflow, this can be ignored as the editor should not be affected.
+- If the MWE workflow can not be found as run configuration, it might help to reinstall the Xtext plugin or download the eclipse package linked in the first handbook again.
 
 ## For developers
 The project consists of three different parts:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 1. Install eMoflon IBeX: https://github.com/eMoflon/emoflon-ibex-democles and everything you need for the third IBeX handbook (Xtext, Xtend, ...)
 2. Import this PSF file into your workspace:  ** to be added **
 3. Alternatively, clone the repository and import the full.psf file into your workspace
-3. Run GenerateVnf.mwe2 as an MWE workflow (see third handbook)
-4. Choose all projects and hit the black IBeX build hammer in the toolbar
+4. Go into Window -> Preferences -> Emfatic and activate "Automatically greate Ecore (\*.ecore) file when saving emfatic (\*.emf) file."
+5. Locate the VNF.emf file in the project VNF -> model -> VNF.emf make an arbitrary change like adding a whitespace and save the file.
+6. Locate the QPN.emf file in the project QPN -> model -> QPN.emf make an arbitrary change like adding a whitespace and save the file.
+7. Run GenerateVnf.mwe2 as an MWE workflow (see third handbook)
+8. Choose all projects and hit the black IBeX build hammer in the toolbar
 
 ### To run the editor and create a petri net:
 1. Select the vnf\_to\_qpn\_xtext project in the Package Explorer and choose "Run As: Eclipse Application"
@@ -18,6 +21,10 @@
 ### To view the petri net:
 1. Download and install the Petri Net modeling tool [TimeNET](https://timenet.tu-ilmenau.de/#/)
 2. Open the qpn.xml file from the runtime workspace the new eclipse instance created automatically (probably called "runtime-EclipseApplication" or something similar)
+
+### Troubleshooting
+
+- If an error occurrs in the vnf\_to\_qpn\_xtext.ui.tests project while cleaning, building and generating the workflow, this can be ignored as the editor should not be affected.
 
 ## For developers
 The project consists of three different parts:

--- a/full.psf
+++ b/full.psf
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <psf version="2.0">
 <provider id="org.eclipse.egit.core.GitProvider">
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,QPN"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,Testsuite_VNF_to_QPN"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,Transform_VNF_QPN"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,Transform_Xtext_VNF"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,VNF"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,VNF_to_QPN_Rules"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,vnf_to_qpn_xtext"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,vnf_to_qpn_xtext.ide"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,vnf_to_qpn_xtext.tests"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,vnf_to_qpn_xtext.ui"/>
-<project reference="1.0,https://git.cs.upb.de/martenls/mbse-qpns.git,master,vnf_to_qpn_xtext.ui.tests"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,QPN"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,Testsuite_VNF_to_QPN"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,Transform_VNF_QPN"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,Transform_Xtext_VNF"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,VNF"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,VNF_to_QPN_Rules"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,vnf_to_qpn_xtext"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,vnf_to_qpn_xtext.ide"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,vnf_to_qpn_xtext.tests"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,vnf_to_qpn_xtext.ui"/>
+<project reference="1.0,https://github.com/CN-UPB/nfv-dsl-qpn.git,master,vnf_to_qpn_xtext.ui.tests"/>
 </provider>
 </psf>


### PR DESCRIPTION
We updated the README to include the necessary steps for generating the models as we discovered that we did not push them due to our gitignore. We were told pushing the .ecore files would make working with git harder.
Also we updated the full.psf to include the correct links to your repository instead of ours. Now one should be able to import the project.